### PR TITLE
Add maximum message size

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -63,6 +63,8 @@ pub const TEAMS: [(&'static str, &'static str); 6] = [
 pub const JOINCODE_LENGTH: u32 = 6;
 pub const JOINCODE_CHARS: [char; 10] = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
 
+pub const MAXIMUM_PACKET_SIZE: i32 = 512;
+
 pub mod routes {
     pub mod openplanet {
         pub const BASE: &'static str = "https://openplanet.dev";

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -131,6 +131,11 @@ impl Protocol {
         let mut reader = &self.socket;
         reader.read_exact(&mut buf).await?;
         let size = i32::from_le_bytes(buf);
+
+        if size < 1 || size > config::MAXIMUM_PACKET_SIZE {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, "Invalid packet size"));
+        }
+
         let mut msg_buf = vec![0; size as usize];
         reader.read_exact(&mut msg_buf).await?;
         let message = String::from_utf8(msg_buf)


### PR DESCRIPTION
Sending invalid length data leads to problems:
- Out of memory for very large values
- Panic/crash for values less than 0

This fixes this by checking the size before trying to allocate the buffer.

I chose 512 bytes as the maximum message size. If I saw it correctly, the biggest request is CreateRoom, with a payload of about 120 bytes. With a bit to spare, 512 seems to be a sensible choice.